### PR TITLE
Add an default image if the url image is not valid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'uglifier'
 gem 'webpacker'
 gem "nokogiri", ">= 1.10.8"
 gem "rack", ">= 2.0.8"
+gem 'uri'
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/app/views/gardens/_garden_card.html.erb
+++ b/app/views/gardens/_garden_card.html.erb
@@ -1,6 +1,10 @@
 <%= link_to garden_path(garden) do %>
   <div class="card-garden">
-    <%= image_tag garden.banner_url %>
+    <% if (garden.banner_url =~ URI::regexp).nil? %>
+      <%= image_tag 'https://www.dickson-constant.com/medias/images/catalogue/api/m654-grey-680.jpg' %>
+    <% else %>
+      <%= image_tag garden.banner_url %>
+    <% end %>
     <div class="card-garden-infos">
       <div>
         <h2><%= garden.name %></h2>


### PR DESCRIPTION
I don't know if it's wanted or not (for the certification), but there is a 500 error when the garden's banner url is not valid.

What do you think about that ?

Lior, student at Le Wagon